### PR TITLE
client/refactor: change logic for checking if the response is successful after authentication

### DIFF
--- a/client/src/components/Login/Login.jsx
+++ b/client/src/components/Login/Login.jsx
@@ -10,21 +10,21 @@ import styles from './login.module.css';
 export const Login = () => {
     const { login, user, serverError, clearServerErrors } = useAuthStore();
     const navigate = useNavigate()
-    const { formValues, formErrors, onChange, onSubmit, onFocus, success, focusedField, fieldRequirements, inputRefsMapper } = useForm({
+    const { formValues, formErrors, onChange, onSubmit, onFocus, isResponseStatusSuccessful, focusedField, fieldRequirements, inputRefsMapper } = useForm({
         email: '',
         password: '',
     }, login, validateAuth);
 
     useEffect(() => {
         clearServerErrors()
-        if (success) {
+        if (isResponseStatusSuccessful) {
             if (user.hasProfile) {
                 navigate('/');
             } else if (user.hasProfile == false) {
                 navigate('/profile/create');
             }
         }
-    }, [success]);
+    }, [isResponseStatusSuccessful]);
 
     return (
         <section className={styles.login}>

--- a/client/src/components/Register/Register.jsx
+++ b/client/src/components/Register/Register.jsx
@@ -10,7 +10,7 @@ import styles from './register.module.css';
 export const Register = () => {
     const { register, serverError, clearServerErrors } = useAuthStore()
     const navigate = useNavigate()
-    const { formValues, formErrors, onChange, onSubmit, onFocus, success, focusedField, fieldRequirements, inputRefsMapper } = useForm({
+    const { formValues, formErrors, onChange, onSubmit, onFocus, isResponseStatusSuccessful, focusedField, fieldRequirements, inputRefsMapper } = useForm({
         email: '',
         password: '',
         repeatPassword: '',
@@ -18,10 +18,10 @@ export const Register = () => {
 
     useEffect(() => {
         clearServerErrors();
-        if (success == true) {
+        if (isResponseStatusSuccessful) {
             navigate('/profile/create');
         }
-    }, [success]);
+    }, [isResponseStatusSuccessful]);
 
     return (
         <section className={styles.register}>

--- a/client/src/hooks/useForm.js
+++ b/client/src/hooks/useForm.js
@@ -10,7 +10,8 @@ export const useForm = (initialValues, submitHandler, validator) => {
 	const [focusedField, setFocusedField] = useState(initialValues);
 
 	const [fieldRequirements, setFieldRequirements] = useState(initialValues);
-	const [success, setSuccess] = useState(false);
+	const [isResponseStatusSuccessful, setIsResponseStatusSuccessful] =
+		useState(false);
 
 	// Create ref for every key of initial values and map that ref with the key
 	// email:useRef(),
@@ -107,9 +108,10 @@ export const useForm = (initialValues, submitHandler, validator) => {
 			return;
 		}
 
-		// Check if request is successful
-		const isSuccessful = await submitHandler(formValues);
-		setSuccess(isSuccessful);
+		const responseStatus = await submitHandler(formValues);
+		setIsResponseStatusSuccessful(
+			responseStatus == "success" ? true : false
+		);
 	};
 
 	return {
@@ -118,7 +120,7 @@ export const useForm = (initialValues, submitHandler, validator) => {
 		onChange,
 		onSubmit,
 		onFocus,
-		success,
+		isResponseStatusSuccessful,
 		focusedField,
 		fieldRequirements,
 		inputRefsMapper,

--- a/client/src/stores/authStore.jsx
+++ b/client/src/stores/authStore.jsx
@@ -19,11 +19,11 @@ export const useAuthStore = create(
 								set({ user: user });
 								// Set isDisabledGuestRequiredRouteGuard to true if login is successful because i want to redirect to create profile on login by useEffect instead of route guard redirection.
 								set((state) => ({ ...state, serverError: '', isDisabledGuestRequiredGuard: true }));
-								return true;
+								return userData.status;
 
 							} catch (error) {
 								set((state) => ({ ...state, serverError: error.message }));
-								return false;
+								return error.status;
 							}
 						},
 


### PR DESCRIPTION
Auth store authenticate function return response status provided by the server instead of returning true/false.

useForm hook rename variable named success to isResponseStatusSuccessful and set isResponseStatusSuccessful by ternary operator instead of receiving true/false from authStore.

Rename variables named success to isResponseStatusSuccessful in register and login components.