### PR TITLE
client/feat: Add logic to change hasProfile property into localStorage and user state after profile creation

### DIFF
--- a/client/src/components/CreateProfile/CreateProfile.jsx
+++ b/client/src/components/CreateProfile/CreateProfile.jsx
@@ -1,7 +1,11 @@
 import { useEffect } from 'react';
+// import { useNavigate } from 'react-router-dom'
+
 import { ProfileForm } from '../Common/ProfileForm/ProfileForm';
 import { useForm } from '../../hooks/useForm';
 import { useProfileStore } from '../../stores/profileStore';
+import { useAuthStore } from '../../stores/authStore'
+
 import { validateProfile } from '../Common/ProfileForm/validateProfile';
 
 
@@ -11,8 +15,10 @@ import { FaCircleCheck } from "react-icons/fa6";
 
 import styles from './create-profile.module.css';
 export const CreateProfile = () => {
-    const { createProfile, serverError, clearServerErrors } = useProfileStore()
-    const { formValues, formErrors, onChange, onSubmit, onFocus, focusedField, fieldRequirements, inputRefsMapper } = useForm({
+    const { createProfile, serverError, clearServerErrors } = useProfileStore();
+    const { updateUser } = useAuthStore();
+    // const navigate = useNavigate();
+    const { formValues, formErrors, onChange, onSubmit, onFocus, isResponseStatusSuccessful, focusedField, fieldRequirements, inputRefsMapper } = useForm({
         age: '',
         height: '',
         currentWeight: '',
@@ -22,10 +28,16 @@ export const CreateProfile = () => {
         gender: 'male',
     }, createProfile, validateProfile);
 
+
     // It removes server error from profile state if any.
     useEffect(() => {
         clearServerErrors();
-    }, [])
+        if (isResponseStatusSuccessful) {
+            updateUser('hasProfile', true);
+            // navigate('/');
+        }
+
+    }, [isResponseStatusSuccessful])
     return (
         <>
             <section className={styles.hero}>

--- a/client/src/stores/authStore.jsx
+++ b/client/src/stores/authStore.jsx
@@ -12,6 +12,11 @@ export const useAuthStore = create(
 						serverError: '',
 						// On page reload / manually type url -> enable guest required route guard 
 						isDisabledGuestRequiredGuard: false,
+
+						updateUser: (key, value) => {
+							set((state) => ({ user: { ...state.user, [key]: value } }));
+						},
+
 						authenticate: async (credentials, action) => {
 							try {
 								const responseResult = await action(credentials);

--- a/client/src/stores/profileStore.jsx
+++ b/client/src/stores/profileStore.jsx
@@ -12,10 +12,12 @@ export const useProfileStore = create(
                     createProfile: async (profileData) => {
                         try {
                             const profileService = profileServiceFactory();
-                            const result = await profileService.createProfile(profileData);
-                            set({ profile: result })
+                            const responseResult = await profileService.createProfile(profileData);
+                            set({ profile: responseResult });
+                            return responseResult.status;
                         } catch (error) {
                             set((state) => ({ ...state, serverError: error.message }));
+                            return error.status;
 
                         }
                     },


### PR DESCRIPTION
### Summary:
This PR adds the following functionality to the existing profile creation flow:
1. Logic to save `hasProfile: true` in user state and accordingly in localStorage upon successful profile creation.

### Changes:
1. Added `isResponseStatusSuccessful` variable which is returned by useForm hook into `CreateProfile`.
2. Added `updateUser` functionality into `authStore`.
3. Update `createProfile` to return response status into `profileStore`.