### PR TITLE
client/fix: First table row hover animation go under the thead

### DIFF
--- a/client/src/components/Diary/Diary.jsx
+++ b/client/src/components/Diary/Diary.jsx
@@ -1,8 +1,19 @@
+import { useState, useCallback } from 'react';
 import { Select } from 'antd';
 import { FiEdit, FiDelete } from "react-icons/fi";
 
 import styles from './diary.module.css'
 export const Diary = () => {
+    const [isScrolled, setIsScrolled] = useState(false);
+
+    const onScrollHandler = (e) => {
+        const currentScrollTopValue = e.target.scrollTop;
+        const hasScrolled = currentScrollTopValue > 0;
+        if (hasScrolled != isScrolled) {
+            setIsScrolled(hasScrolled);
+        }
+    };
+
     return (
         <section className={styles.diary}>
             <div className={styles.headingContainer}>
@@ -28,9 +39,9 @@ export const Diary = () => {
                 />
                 <button>Create Report</button>
             </div>
-            <div className={styles.tableScroll}>
+            <div className={styles.tableScroll} onScroll={(e) => onScrollHandler(e)}>
                 <table className={styles.container}>
-                    <thead>
+                    <thead className={isScrolled && styles.sticky}>
                         <tr>
                             <th><h2>Date </h2></th>
                             <th><h2>Food</h2></th>

--- a/client/src/components/Diary/diary.module.css
+++ b/client/src/components/Diary/diary.module.css
@@ -51,6 +51,9 @@
 
 .container th {
 	background-color: #242424;
+}
+
+.sticky {
 	position: sticky;
 	top: -1px;
 	z-index: 2;


### PR DESCRIPTION
### Summary:
This PR fixes CSS bug:  When first table row is hovered its animation goes under the `tHead`.

### Changes:
1. Implemented `onScrollHandler` function which changes `isScrolled` state when user has scrolled.
2. Implementation of `onScrollHandler` avoid unnecessary `isScrolled` state changes and re-renders.
3. Removed statically written css with position sticky for all `th` HTML elements.
4. If `isScrolled: true` dynamically applies `.sticky` class to `tHead` HTML element.

Related PRs:
- Introduced in PR #10