### PR TITLE
client/fix: Thead received false for non-boolean attribute classname

### DIFF
--- a/client/src/components/Diary/Diary.jsx
+++ b/client/src/components/Diary/Diary.jsx
@@ -59,7 +59,7 @@ export const Diary = () => {
             </div>
             <div className={styles.tableScroll} onScroll={(e) => onScrollHandler(e)}>
                 <table className={styles.container}>
-                    <thead className={isScrolled && styles.sticky}>
+                    <thead className={isScrolled ? styles.sticky : undefined}>
                         <tr>
                             <th><h2>Date </h2></th>
                             <th><h2>Food</h2></th>


### PR DESCRIPTION
### Summary:
This PR fixes error which appears in `Diary` component `thead`.Caused by conditional rendering when `isScrolled` state is `false`.

### Changes:
1. Instead of add `false` as `className` value when `isScrolled:false`, add `undefined` as className value.