### PR TITLE
client/style: Implement new diary modal's input styling

### DIFF
--- a/client/src/components/Diary/DiaryModal/diary-modal.module.css
+++ b/client/src/components/Diary/DiaryModal/diary-modal.module.css
@@ -2,3 +2,14 @@
 	display: flex;
 	color: #e8e8e8;
 }
+
+.modalForm input {
+	margin-top: 5px;
+	outline: none;
+}
+
+.modalForm input:focus {
+	border-color: orange;
+    background-color: #3c3c3c;
+
+}


### PR DESCRIPTION
### Summary:
This PR changes input field's border colour when focused.Previously, the border was blue, now it turns orange. Enhances user experience by providing better indication of focus state.

### Changes:
1. Added input's `margin-top:5px`.
2. Removed default outline.
3. Added `:focus` selector to change `border-colour` to orange.